### PR TITLE
Replace broken Transit API pin endpoint with inline SVG

### DIFF
--- a/client/directives/routeItem/routeItem.css
+++ b/client/directives/routeItem/routeItem.css
@@ -112,10 +112,7 @@
 
 .route .stop_name {
   position: relative;
-  background-repeat: no-repeat;
-  background-position: 0 0.05em;
-  background-size: auto 1em;
-  padding-left: 1em;
+  padding-left: 1.1em;
 
   font-size: 1.4em;
   margin-bottom: 0.4em;
@@ -124,6 +121,16 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+}
+
+.route .stop_name .pin-icon {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1em;
+  height: 1em;
+  fill: currentColor;
 }
 
 

--- a/client/directives/routeItem/routeItem.html
+++ b/client/directives/routeItem/routeItem.html
@@ -12,8 +12,8 @@
   </h2>
 
   <div class="content" ng-repeat="dir in route.itineraries" ng-if="dir">
-    <div class="stop_name" ng-style="{'background-image': 'url(\'' + ctrl.getPinUrl(route) + '\')'}">
-      {{ dir.closest_stop ? dir.closest_stop.stop_name : 'Unknown stop' }}
+    <div class="stop_name">
+      <svg class="pin-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><path d="M128 252.6C128 148.4 214 64 320 64C426 64 512 148.4 512 252.6C512 371.9 391.8 514.9 341.6 569.4C329.8 582.2 310.1 582.2 298.3 569.4C248.1 514.9 127.9 371.9 127.9 252.6zM320 320C355.3 320 384 291.3 384 256C384 220.7 355.3 192 320 192C284.7 192 256 220.7 256 256C256 291.3 284.7 320 320 320z"/></svg>{{ dir.closest_stop ? dir.closest_stop.stop_name : 'Unknown stop' }}
     </div>
     <div class="direction" ng-style="ctrl.getCellStyle(route)">
       <h3 ng-bind="dir.merged_headsign || 'Unknown destination'"></h3>


### PR DESCRIPTION
The external endpoint at widget.transitapp.com/images/.../pin.png no longer responds. Replaced with Font Awesome map pin SVG that inherits route colors via fill: currentColor.

Generated with Claude Code